### PR TITLE
chore!: changed package path and repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Therefore, a dax interface can make clear which methods are used in a logic. And
 
 The usage of this framework is described on the overview in the go package document.
 
-See https://pkg.go.dev/github.com/sttk-go/sabi#pkg-overview.
+See https://pkg.go.dev/github.com/sttk/sabi#pkg-overview.
 
 
 ## Supporting Go versions
@@ -46,15 +46,15 @@ This framework supports Go 1.18 or later.
 % gvm-fav
 Now using version go1.18.10
 go version go1.18.10 darwin/amd64
-ok  	github.com/sttk-go/sabi	0.834s	coverage: 99.6% of statements
+ok  	github.com/sttk/sabi	0.834s	coverage: 99.6% of statements
 
 Now using version go1.19.5
 go version go1.19.5 darwin/amd64
-ok  	github.com/sttk-go/sabi	0.836s	coverage: 99.6% of statements
+ok  	github.com/sttk/sabi	0.836s	coverage: 99.6% of statements
 
 Now using version go1.20
 go version go1.20 darwin/amd64
-ok  	github.com/sttk-go/sabi	0.843s	coverage: 99.6% of statements
+ok  	github.com/sttk/sabi	0.843s	coverage: 99.6% of statements
 
 Back to go1.20
 Now using version go1.20
@@ -70,10 +70,10 @@ This program is free software under MIT License.<br>
 See the file LICENSE in this distribution for more details.
 
 
-[repo-url]: https://github.com/sttk-go/sabi
-[pkg-dev-img]: https://pkg.go.dev/badge/github.com/sttk-go/sabi.svg
-[pkg-dev-url]: https://pkg.go.dev/github.com/sttk-go/sabi
-[ci-img]: https://github.com/sttk-go/sabi/actions/workflows/go.yml/badge.svg?branch=main
-[ci-url]: https://github.com/sttk-go/sabi/actions
+[repo-url]: https://github.com/sttk/sabi-go
+[pkg-dev-img]: https://pkg.go.dev/badge/github.com/sttk/sabi.svg
+[pkg-dev-url]: https://pkg.go.dev/github.com/sttk/sabi
+[ci-img]: https://github.com/sttk/sabi-go/actions/workflows/go.yml/badge.svg?branch=main
+[ci-url]: https://github.com/sttk/sabi-go/actions
 [mit-img]: https://img.shields.io/badge/license-MIT-green.svg
 [mit-url]: https://opensource.org/licenses/MIT

--- a/benchmark/dax_src/benchmark_dax_src_test.go
+++ b/benchmark/dax_src/benchmark_dax_src_test.go
@@ -1,8 +1,9 @@
 package sabi_test
 
 import (
-	"github.com/sttk-go/sabi"
 	"testing"
+
+	"github.com/sttk/sabi"
 )
 
 type FooDaxConn struct{}

--- a/benchmark/err/benchmark_err_test.go
+++ b/benchmark/err/benchmark_err_test.go
@@ -1,9 +1,10 @@
 package sabi_test
 
 import (
-	"github.com/sttk-go/sabi"
 	"strconv"
 	"testing"
+
+	"github.com/sttk/sabi"
 )
 
 func unused(v any) {}

--- a/benchmark/notify/benchmark_notify_test.go
+++ b/benchmark/notify/benchmark_notify_test.go
@@ -1,8 +1,9 @@
 package sabi_test
 
 import (
-	"github.com/sttk-go/sabi"
 	"testing"
+
+	"github.com/sttk/sabi"
 )
 
 func unused(v any) {}

--- a/dax_dummy_for_test.go
+++ b/dax_dummy_for_test.go
@@ -2,7 +2,8 @@ package sabi_test
 
 import (
 	"container/list"
-	"github.com/sttk-go/sabi"
+
+	"github.com/sttk/sabi"
 )
 
 var (

--- a/dax_test.go
+++ b/dax_test.go
@@ -2,9 +2,11 @@ package sabi_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/sttk-go/sabi"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sttk/sabi"
 )
 
 func TestAddGlobalDaxSrc(t *testing.T) {
@@ -773,12 +775,12 @@ func TestGetDaxConn_whenDaxConnIsValueButError(t *testing.T) {
 	conn, err := sabi.GetDaxConn[*BarDaxConn](base, "foo")
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "FailToCastDaxConn")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi")
 	assert.Equal(t, err.Get("Name"), "foo")
 	assert.Equal(t, err.Get("FromType"),
-		"FooDaxConn (github.com/sttk-go/sabi_test)")
+		"FooDaxConn (github.com/sttk/sabi_test)")
 	assert.Equal(t, err.Get("ToType"),
-		"*BarDaxConn (github.com/sttk-go/sabi_test)")
+		"*BarDaxConn (github.com/sttk/sabi_test)")
 	assert.Nil(t, conn)
 }
 
@@ -791,12 +793,12 @@ func TestGetDaxConn_whenDaxConnIsValueButPointer(t *testing.T) {
 	conn, err := sabi.GetDaxConn[*FooDaxConn](base, "foo")
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "FailToCastDaxConn")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi")
 	assert.Equal(t, err.Get("Name"), "foo")
 	assert.Equal(t, err.Get("FromType"),
-		"FooDaxConn (github.com/sttk-go/sabi_test)")
+		"FooDaxConn (github.com/sttk/sabi_test)")
 	assert.Equal(t, err.Get("ToType"),
-		"*FooDaxConn (github.com/sttk-go/sabi_test)")
+		"*FooDaxConn (github.com/sttk/sabi_test)")
 	assert.Nil(t, conn)
 }
 
@@ -821,12 +823,12 @@ func TestGetDaxConn_whenDaxConnIsPointerButError(t *testing.T) {
 	conn, err := sabi.GetDaxConn[*FooDaxConn](base, "bar")
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "FailToCastDaxConn")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi")
 	assert.Equal(t, err.Get("Name"), "bar")
 	assert.Equal(t, err.Get("FromType"),
-		"*BarDaxConn (github.com/sttk-go/sabi_test)")
+		"*BarDaxConn (github.com/sttk/sabi_test)")
 	assert.Equal(t, err.Get("ToType"),
-		"*FooDaxConn (github.com/sttk-go/sabi_test)")
+		"*FooDaxConn (github.com/sttk/sabi_test)")
 	assert.Nil(t, conn)
 }
 
@@ -840,12 +842,12 @@ func TestGetDaxConn_whenDaxConnIsPointerButValue(t *testing.T) {
 	conn, err := sabi.GetDaxConn[BarDaxConn](base, "bar")
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "FailToCastDaxConn")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi")
 	assert.Equal(t, err.Get("Name"), "bar")
 	assert.Equal(t, err.Get("FromType"),
-		"*BarDaxConn (github.com/sttk-go/sabi_test)")
+		"*BarDaxConn (github.com/sttk/sabi_test)")
 	assert.Equal(t, err.Get("ToType"),
-		"BarDaxConn (github.com/sttk-go/sabi_test)")
+		"BarDaxConn (github.com/sttk/sabi_test)")
 	assert.NotNil(t, conn)
 }
 */
@@ -858,7 +860,7 @@ func TestGetDaxConn_whenDaxConnIsNotFound(t *testing.T) {
 	conn, err := sabi.GetDaxConn[FooDaxConn](base, "foo")
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "DaxSrcIsNotFound")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi")
 	assert.Equal(t, err.Get("Name"), "foo")
 	assert.NotNil(t, conn)
 }
@@ -874,7 +876,7 @@ func TestGetDaxConn_whenDaxConnIsFailedToCreate(t *testing.T) {
 	conn, err := sabi.GetDaxConn[FooDaxConn](base, "foo")
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "FailToCreateDaxConn")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi")
 	assert.Equal(t, err.Get("Name"), "foo")
 	assert.NotNil(t, conn)
 }

--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,7 @@
 // See the file LICENSE in this distribution for more details.
 
 /*
-Package github.com/sttk-go/sabi is a small framework to separate logic parts and data accesses parts for Golang applications.
+Package github.com/sttk/sabi is a small framework to separate logic parts and data accesses parts for Golang applications.
 
 # Logic
 
@@ -15,7 +15,7 @@ In this logic part, it's no concern where a data comes from or goes to.
 
 For example, in the following code, GreetLogic is a logic function and GreetDax is a dax interface.
 
-	import "github.com/sttk-go/sabi"
+	import "github.com/sttk/sabi"
 
 	type GreetDax interface {
 		UserName() (string, sabi.Err)

--- a/doc_test.go
+++ b/doc_test.go
@@ -2,9 +2,11 @@ package sabi_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/sttk-go/sabi"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sttk/sabi"
 )
 
 type GreetDax interface {

--- a/err_test.go
+++ b/err_test.go
@@ -2,9 +2,11 @@ package sabi_test
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/sttk-go/sabi"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sttk/sabi"
 )
 
 type /* error reasons */ (
@@ -38,7 +40,7 @@ func TestNewErr_reasonIsValue(t *testing.T) {
 	assert.False(t, err.IsOk())
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "InvalidValue")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi_test")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi_test")
 	assert.Equal(t, err.Get("Value"), "abc")
 	assert.Nil(t, err.Get("value"))
 	assert.Nil(t, err.Get("Name"))
@@ -74,7 +76,7 @@ func TestNewErr_reasonIsPointer(t *testing.T) {
 	assert.False(t, err.IsOk())
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "InvalidValue")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi_test")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi_test")
 	assert.Equal(t, err.Get("Value"), "abc")
 	assert.Nil(t, err.Get("value"))
 	assert.Nil(t, err.Get("Name"))
@@ -111,7 +113,7 @@ func TestNewErr_withCause(t *testing.T) {
 	assert.False(t, err.IsOk())
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "InvalidValue")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi_test")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi_test")
 	assert.Equal(t, err.Get("Value"), "abc")
 	assert.Nil(t, err.Get("value"))
 	assert.Nil(t, err.Get("Name"))
@@ -150,7 +152,7 @@ func TestNewErr_causeIsAlsoErr(t *testing.T) {
 	assert.False(t, err.IsOk())
 	assert.True(t, err.IsNotOk())
 	assert.Equal(t, err.ReasonName(), "InvalidValue")
-	assert.Equal(t, err.ReasonPackage(), "github.com/sttk-go/sabi_test")
+	assert.Equal(t, err.ReasonPackage(), "github.com/sttk/sabi_test")
 
 	assert.Equal(t, err.Get("Value"), "abc")
 	assert.Equal(t, err.Get("Name"), "foo")

--- a/example_dax_test.go
+++ b/example_dax_test.go
@@ -2,8 +2,9 @@ package sabi_test
 
 import (
 	"fmt"
-	"github.com/sttk-go/sabi"
 	"reflect"
+
+	"github.com/sttk/sabi"
 )
 
 func ExampleAddGlobalDaxSrc() {

--- a/example_err_test.go
+++ b/example_err_test.go
@@ -3,7 +3,8 @@ package sabi_test
 import (
 	"errors"
 	"fmt"
-	"github.com/sttk-go/sabi"
+
+	"github.com/sttk/sabi"
 )
 
 func ExampleNewErr() {
@@ -164,7 +165,7 @@ func ExampleErr_ReasonPackage() {
 	fmt.Printf("%v\n", err.ReasonPackage())
 
 	// Output:
-	// github.com/sttk-go/sabi_test
+	// github.com/sttk/sabi_test
 }
 
 func ExampleErr_Situation() {

--- a/example_notify_test.go
+++ b/example_notify_test.go
@@ -2,9 +2,10 @@ package sabi_test
 
 import (
 	"fmt"
-	"github.com/sttk-go/sabi"
 	"strconv"
 	"time"
+
+	"github.com/sttk/sabi"
 )
 
 func ExampleAddAsyncErrHandler() {
@@ -57,7 +58,7 @@ func ExampleFixErrCfgs() {
 	sabi.NewErr(FailToDoSomething{Name: "abc"})
 
 	// Output:
-	// This handler is registered at example_notify_test.go:57
+	// This handler is registered at example_notify_test.go:58
 
 	sabi.ClearErrHandlers()
 }

--- a/example_runner_test.go
+++ b/example_runner_test.go
@@ -1,7 +1,7 @@
 package sabi_test
 
 import (
-	"github.com/sttk-go/sabi"
+	"github.com/sttk/sabi"
 )
 
 func unused(v any) {}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/sttk-go/sabi
+module github.com/sttk/sabi
 
 go 1.18
 
-require github.com/stretchr/testify v1.8.3
+require github.com/stretchr/testify v1.8.4
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/notify_test.go
+++ b/notify_test.go
@@ -2,11 +2,12 @@ package sabi
 
 import (
 	"container/list"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type ReasonForNotification struct{}
@@ -201,13 +202,13 @@ func TestNotifyErr_withHandlers(t *testing.T) {
 
 	assert.Equal(t, syncLogs.Len(), 2)
 	assert.Equal(t, syncLogs.Front().Value,
-		"ReasonForNotification-1:notify_test.go:198")
+		"ReasonForNotification-1:notify_test.go:199")
 	assert.Equal(t, syncLogs.Front().Next().Value,
-		"ReasonForNotification-2:notify_test.go:198")
+		"ReasonForNotification-2:notify_test.go:199")
 
 	time.Sleep(100 * time.Millisecond)
 
 	assert.Equal(t, asyncLogs.Len(), 1)
 	assert.Equal(t, asyncLogs.Front().Value,
-		"ReasonForNotification-3:notify_test.go:198")
+		"ReasonForNotification-3:notify_test.go:199")
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -2,10 +2,12 @@ package sabi_test
 
 import (
 	"container/list"
-	"github.com/stretchr/testify/assert"
-	"github.com/sttk-go/sabi"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sttk/sabi"
 )
 
 var runnerLogs list.List

--- a/txn_test.go
+++ b/txn_test.go
@@ -1,10 +1,12 @@
 package sabi_test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/sttk-go/sabi"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sttk/sabi"
 )
 
 func TestRunTxn(t *testing.T) {


### PR DESCRIPTION
This PR changes package path and repository name of this package.

This package was originally in `sttk-go` project, and that package path and repository path were `github.com/sttk-go/sabi`.